### PR TITLE
Add docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,24 @@
-FROM quay.io/prometheus/busybox:latest
+FROM golang:1.15.3 AS builder
 
-COPY sentry_exporter  /bin/sentry_exporter
-COPY sentry_exporter.yml       /etc/sentry_exporter/config.yml
+WORKDIR /src/go/github.com/snakecharmer/sentry_exporter
 
-EXPOSE      9412
-ENTRYPOINT  [ "/bin/sentry_exporter" ]
-CMD         [ "-config.file=/etc/sentry_exporter/config.yml" ]
+COPY . .
+
+RUN go get -d -v
+RUN go build -o sentry_exporter .
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app/
+
+# https://stackoverflow.com/a/35613430
+RUN mkdir -p /etc/sentry_exporter/ && mkdir /lib64 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+COPY --from=builder /src/go/github.com/snakecharmer/sentry_exporter .
+COPY sentry_exporter.yml /etc/sentry_exporter/config.yml
+
+EXPOSE 9412
+ENTRYPOINT ["./sentry_exporter"]
+CMD ["--config.file=/etc/sentry_exporter/config.yml"]

--- a/sentry_exporter.yml
+++ b/sentry_exporter.yml
@@ -3,6 +3,6 @@ modules:
     prober: http
     timeout: 5s
     http:
-      prefix: https://sentry.com/api/0/projects/{namespace}/
+      prefix: https://sentry.io/api/0/projects/
       headers:
         Authorization: Bearer {Token}

--- a/sentry_exporter.yml
+++ b/sentry_exporter.yml
@@ -3,6 +3,6 @@ modules:
     prober: http
     timeout: 5s
     http:
-      prefix: https://sentry.io/api/0/projects/
+      prefix: https://sentry.io/api/0/projects/{organization_slug}
       headers:
         Authorization: Bearer {Token}


### PR DESCRIPTION
Add Docker build support using [multi-stage build strategy](https://docs.docker.com/develop/develop-images/multistage-build/)
```
docker build -t italux/sentry_exporter:v0.1.0 .
Sending build context to Docker daemon  153.6kB
Step 1/14 : FROM golang:1.15.3 AS builder
 ---> 4a581cd6feb1
Step 2/14 : WORKDIR /src/go/github.com/snakecharmer/sentry_exporter
 ---> Using cache
 ---> cea3e0debade
Step 3/14 : COPY . .
 ---> e939c094c35d
Step 4/14 : RUN go get -d -v
 ---> Running in 259c2001f45a
github.com/prometheus/client_golang (download)
github.com/beorn7/perks (download)
github.com/cespare/xxhash (download)
github.com/golang/protobuf (download)
get "google.golang.org/protobuf/encoding/prototext": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/encoding/prototext?go-get=1
get "google.golang.org/protobuf/encoding/prototext": verifying non-authoritative meta tag
google.golang.org/protobuf (download)
get "google.golang.org/protobuf/encoding/protowire": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/encoding/protowire?go-get=1
get "google.golang.org/protobuf/encoding/protowire": verifying non-authoritative meta tag
get "google.golang.org/protobuf/reflect/protoreflect": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/reflect/protoreflect?go-get=1
get "google.golang.org/protobuf/reflect/protoreflect": verifying non-authoritative meta tag
get "google.golang.org/protobuf/proto": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/proto?go-get=1
get "google.golang.org/protobuf/proto": verifying non-authoritative meta tag
get "google.golang.org/protobuf/reflect/protoregistry": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/reflect/protoregistry?go-get=1
get "google.golang.org/protobuf/reflect/protoregistry": verifying non-authoritative meta tag
get "google.golang.org/protobuf/runtime/protoiface": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/runtime/protoiface?go-get=1
get "google.golang.org/protobuf/runtime/protoiface": verifying non-authoritative meta tag
get "google.golang.org/protobuf/runtime/protoimpl": found meta tag get.metaImport{Prefix:"google.golang.org/protobuf", VCS:"git", RepoRoot:"https://go.googlesource.com/protobuf"} at //google.golang.org/protobuf/runtime/protoimpl?go-get=1
get "google.golang.org/protobuf/runtime/protoimpl": verifying non-authoritative meta tag
github.com/prometheus/client_model (download)
github.com/prometheus/common (download)
github.com/matttproud/golang_protobuf_extensions (download)
github.com/prometheus/procfs (download)
get "golang.org/x/sys/unix": found meta tag get.metaImport{Prefix:"golang.org/x/sys", VCS:"git", RepoRoot:"https://go.googlesource.com/sys"} at //golang.org/x/sys/unix?go-get=1
get "golang.org/x/sys/unix": verifying non-authoritative meta tag
golang.org/x/sys (download)
github.com/sirupsen/logrus (download)
get "gopkg.in/alecthomas/kingpin.v2": found meta tag get.metaImport{Prefix:"gopkg.in/alecthomas/kingpin.v2", VCS:"git", RepoRoot:"https://gopkg.in/alecthomas/kingpin.v2"} at //gopkg.in/alecthomas/kingpin.v2?go-get=1
gopkg.in/alecthomas/kingpin.v2 (download)
github.com/alecthomas/template (download)
github.com/alecthomas/units (download)
get "gopkg.in/yaml.v2": found meta tag get.metaImport{Prefix:"gopkg.in/yaml.v2", VCS:"git", RepoRoot:"https://gopkg.in/yaml.v2"} at //gopkg.in/yaml.v2?go-get=1
gopkg.in/yaml.v2 (download)
Removing intermediate container 259c2001f45a
 ---> 6a646d7024be
Step 5/14 : RUN go build -o sentry_exporter .
 ---> Running in eecab9b496fa
Removing intermediate container eecab9b496fa
 ---> bce319369881
Step 6/14 : FROM alpine:latest
 ---> a24bb4013296
Step 7/14 : RUN apk --no-cache add ca-certificates
 ---> Using cache
 ---> 65a86ea6e44b
Step 8/14 : WORKDIR /app/
 ---> Using cache
 ---> 6b4f19e0a38f
Step 9/14 : RUN mkdir -p /etc/sentry_exporter/ && mkdir /lib64 &&     ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 ---> Using cache
 ---> 549949b51dd0
Step 10/14 : COPY --from=builder /src/go/github.com/snakecharmer/sentry_exporter .
 ---> ce8f33a165e1
Step 11/14 : COPY sentry_exporter.yml /etc/sentry_exporter/config.yml
 ---> 44d65866fea4
Step 12/14 : EXPOSE 9412
 ---> Running in 9c3c68b44e34
Removing intermediate container 9c3c68b44e34
 ---> 8db23f808eed
Step 13/14 : ENTRYPOINT ["./sentry_exporter"]
 ---> Running in da7f2235e3e6
Removing intermediate container da7f2235e3e6
 ---> e3a35af8ff16
Step 14/14 : CMD ["--config.file=/etc/sentry_exporter/config.yml"]
 ---> Running in 8251f0f2eebd
Removing intermediate container 8251f0f2eebd
 ---> c8939250aee5
Successfully built c8939250aee5
Successfully tagged italux/sentry_exporter:v0.1.0
```